### PR TITLE
print directly from file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,8 @@ PathPlanner/PathPlanner/*.o
 PathPlanner/PathPlanner/*.dep
 PathPlanner/PathPlanner/PathPlannerNative_wrap.cpp
 PathPlanner/PathPlanner/PathPlannerNative.py
+path_planner/PathPlannerNative_wrap.h
+_PathPlannerNative.so
 
 # Ignore PyCharm settings
 /.idea

--- a/redeem/TextWriter.py
+++ b/redeem/TextWriter.py
@@ -1,0 +1,774 @@
+"""
+    textwriter
+    ~~~~~~~~~~
+
+    Standalone docutils writer for plain text.
+"""
+
+import re
+import textwrap
+
+from docutils import nodes, writers
+from docutils.core import publish_string
+
+admonitionlabels = {
+    'attention': 'Attention',
+    'caution': 'Caution',
+    'danger': 'Danger',
+    'error': 'Error',
+    'hint': 'Hint',
+    'important': 'Important',
+    'note': 'Note',
+    'seealso': 'See also',
+    'tip': 'Tip',
+    'warning': 'Warning',
+}
+
+versionlabels = {
+    'versionadded': 'New in version %s',
+    'versionchanged': 'Changed in version %s',
+    'deprecated': 'Deprecated since version %s',
+}
+
+
+class TextWriter(writers.Writer):
+    supported = ('text',)
+    settings_spec = ('No options here.', '', ())
+    settings_defaults = {}
+
+    output = None
+
+    def __init__(self):
+        writers.Writer.__init__(self)
+
+    def translate(self):
+        visitor = TextTranslator(self.document)
+        self.document.walkabout(visitor)
+        self.output = visitor.body
+
+
+# monkey-patch...
+new_wordsep_re = re.compile(
+    r'(\s+|'  # any whitespace
+    r'(?<=\s)(?::[a-z-]+:)?`\S+|'  # interpreted text start
+    r'[^\s\w]*\w+[a-zA-Z]-(?=\w+[a-zA-Z])|'  # hyphenated words
+    r'(?<=[\w\!\"\'\&\.\,\?])-{2,}(?=\w))')  # em-dash
+textwrap.TextWrapper.wordsep_re = new_wordsep_re
+
+MAXWIDTH = 70
+STDINDENT = 3
+
+
+class TextTranslator(nodes.NodeVisitor):
+    sectionchars = '*=-~"+'
+
+    def __init__(self, document):
+        nodes.NodeVisitor.__init__(self, document)
+
+        self.states = [[]]
+        self.stateindent = [0]
+        self.sectionlevel = 0
+        self.table = None
+
+    def add_text(self, text):
+        self.states[-1].append((-1, text))
+
+    def new_state(self, indent=STDINDENT):
+        self.states.append([])
+        self.stateindent.append(indent)
+
+    def end_state(self, wrap=True, end=[''], first=None):
+        content = self.states.pop()
+        maxindent = sum(self.stateindent)
+        indent = self.stateindent.pop()
+        result = []
+        toformat = []
+
+        def do_format():
+            if not toformat:
+                return
+            if wrap:
+                res = textwrap.wrap(''.join(toformat), width=MAXWIDTH - maxindent)
+            else:
+                res = ''.join(toformat).splitlines()
+            if end:
+                res += end
+            result.append((indent, res))
+
+        for itemindent, item in content:
+            if itemindent == -1:
+                toformat.append(item)
+            else:
+                do_format()
+                result.append((indent + itemindent, item))
+                toformat = []
+        do_format()
+        if first is not None and result:
+            itemindent, item = result[0]
+            if item:
+                result.insert(0, (itemindent - indent, [first + item[0]]))
+                result[1] = (itemindent, item[1:])
+        self.states[-1].extend(result)
+
+    def visit_document(self, node):
+        self.new_state(0)
+
+    def depart_document(self, node):
+        self.end_state()
+        self.body = '\n'.join(line and (' ' * indent + line)
+                              for indent, lines in self.states[0]
+                              for line in lines)
+        # XXX header/footer?
+
+    def visit_highlightlang(self, node):
+        raise nodes.SkipNode
+
+    def visit_section(self, node):
+        self._title_char = self.sectionchars[self.sectionlevel]
+        self.sectionlevel += 1
+
+    def depart_section(self, node):
+        self.sectionlevel -= 1
+
+    def visit_topic(self, node):
+        self.new_state(0)
+
+    def depart_topic(self, node):
+        self.end_state()
+
+    visit_sidebar = visit_topic
+    depart_sidebar = depart_topic
+
+    def visit_rubric(self, node):
+        self.new_state(0)
+        self.add_text('-[ ')
+
+    def depart_rubric(self, node):
+        self.add_text(' ]-')
+        self.end_state()
+
+    def visit_compound(self, node):
+        pass
+
+    def depart_compound(self, node):
+        pass
+
+    def visit_glossary(self, node):
+        pass
+
+    def depart_glossary(self, node):
+        pass
+
+    def visit_title(self, node):
+        if isinstance(node.parent, nodes.Admonition):
+            self.add_text(node.astext() + ': ')
+            raise nodes.SkipNode
+        self.new_state(0)
+
+    def depart_title(self, node):
+        if isinstance(node.parent, nodes.section):
+            char = self._title_char
+        else:
+            char = '^'
+        text = ''.join(x[1] for x in self.states.pop() if x[0] == -1)
+        self.stateindent.pop()
+        self.states[-1].append((0, ['', text, '%s' % (char * len(text)), '']))
+
+    def visit_subtitle(self, node):
+        pass
+
+    def depart_subtitle(self, node):
+        pass
+
+    def visit_attribution(self, node):
+        self.add_text('-- ')
+
+    def depart_attribution(self, node):
+        pass
+
+    def visit_module(self, node):
+        if node.has_key('platform'):
+            self.new_state(0)
+            self.add_text('Platform: {}}'.format(node['platform']))
+            self.end_state()
+        raise nodes.SkipNode
+
+    def visit_desc(self, node):
+        pass
+
+    def depart_desc(self, node):
+        pass
+
+    def visit_desc_signature(self, node):
+        self.new_state(0)
+        if node.parent['desctype'] in ('class', 'exception'):
+            self.add_text('%s ' % node.parent['desctype'])
+
+    def depart_desc_signature(self, node):
+        # XXX: wrap signatures in a way that makes sense
+        self.end_state(wrap=False, end=None)
+
+    def visit_desc_name(self, node):
+        pass
+
+    def depart_desc_name(self, node):
+        pass
+
+    def visit_desc_addname(self, node):
+        pass
+
+    def depart_desc_addname(self, node):
+        pass
+
+    def visit_desc_type(self, node):
+        pass
+
+    def depart_desc_type(self, node):
+        pass
+
+    def visit_desc_parameterlist(self, node):
+        self.add_text('(')
+        self.first_param = 1
+
+    def depart_desc_parameterlist(self, node):
+        self.add_text(')')
+
+    def visit_desc_parameter(self, node):
+        if not self.first_param:
+            self.add_text(', ')
+        else:
+            self.first_param = 0
+        self.add_text(node.astext())
+        raise nodes.SkipNode
+
+    def visit_desc_optional(self, node):
+        self.add_text('[')
+
+    def depart_desc_optional(self, node):
+        self.add_text(']')
+
+    def visit_desc_annotation(self, node):
+        pass
+
+    def depart_desc_annotation(self, node):
+        pass
+
+    def visit_refcount(self, node):
+        pass
+
+    def depart_refcount(self, node):
+        pass
+
+    def visit_desc_content(self, node):
+        self.new_state()
+        self.add_text('\n')
+
+    def depart_desc_content(self, node):
+        self.end_state()
+
+    def visit_figure(self, node):
+        self.new_state()
+
+    def depart_figure(self, node):
+        self.end_state()
+
+    def visit_caption(self, node):
+        pass
+
+    def depart_caption(self, node):
+        pass
+
+    def visit_productionlist(self, node):
+        self.new_state()
+        names = []
+        for production in node:
+            names.append(production['tokenname'])
+        maxlen = max(len(name) for name in names)
+        for production in node:
+            if production['tokenname']:
+                self.add_text(production['tokenname'].ljust(maxlen) + ' ::=')
+                lastname = production['tokenname']
+            else:
+                self.add_text('%s    ' % (' ' * len(lastname)))
+            self.add_text(production.astext() + '\n')
+        self.end_state(wrap=False)
+        raise nodes.SkipNode
+
+    def visit_seealso(self, node):
+        self.new_state()
+
+    def depart_seealso(self, node):
+        self.end_state(first='')
+
+    def visit_footnote(self, node):
+        self._footnote = node.children[0].astext().strip()
+        self.new_state(len(self._footnote) + 3)
+
+    def depart_footnote(self, node):
+        self.end_state(first='[%s] ' % self._footnote)
+
+    def visit_citation(self, node):
+        if len(node) and isinstance(node[0], nodes.label):
+            self._citlabel = node[0].astext()
+        else:
+            self._citlabel = ''
+        self.new_state(len(self._citlabel) + 3)
+
+    def depart_citation(self, node):
+        self.end_state(first='[%s] ' % self._citlabel)
+
+    def visit_label(self, node):
+        raise nodes.SkipNode
+
+    # XXX: option list could use some better styling
+
+    def visit_option_list(self, node):
+        pass
+
+    def depart_option_list(self, node):
+        pass
+
+    def visit_option_list_item(self, node):
+        self.new_state(0)
+
+    def depart_option_list_item(self, node):
+        self.end_state()
+
+    def visit_option_group(self, node):
+        self._firstoption = True
+
+    def depart_option_group(self, node):
+        self.add_text('     ')
+
+    def visit_option(self, node):
+        if self._firstoption:
+            self._firstoption = False
+        else:
+            self.add_text(', ')
+
+    def depart_option(self, node):
+        pass
+
+    def visit_option_string(self, node):
+        pass
+
+    def depart_option_string(self, node):
+        pass
+
+    def visit_option_argument(self, node):
+        self.add_text(node['delimiter'])
+
+    def depart_option_argument(self, node):
+        pass
+
+    def visit_description(self, node):
+        pass
+
+    def depart_description(self, node):
+        pass
+
+    def visit_tabular_col_spec(self, node):
+        raise nodes.SkipNode
+
+    def visit_colspec(self, node):
+        self.table[0].append(node['colwidth'])
+        raise nodes.SkipNode
+
+    def visit_tgroup(self, node):
+        pass
+
+    def depart_tgroup(self, node):
+        pass
+
+    def visit_thead(self, node):
+        pass
+
+    def depart_thead(self, node):
+        pass
+
+    def visit_tbody(self, node):
+        self.table.append('sep')
+
+    def depart_tbody(self, node):
+        pass
+
+    def visit_row(self, node):
+        self.table.append([])
+
+    def depart_row(self, node):
+        pass
+
+    def visit_entry(self, node):
+        if node.has_key('morerows') or node.has_key('morecols'):
+            raise NotImplementedError('Column or row spanning cells are '
+                                      'not implemented.')
+        self.new_state(0)
+
+    def depart_entry(self, node):
+        text = '\n'.join('\n'.join(x[1]) for x in self.states.pop())
+        self.stateindent.pop()
+        self.table[-1].append(text)
+
+    def visit_table(self, node):
+        if self.table:
+            raise NotImplementedError('Nested tables are not supported.')
+        self.new_state(0)
+        self.table = [[]]
+
+    def depart_table(self, node):
+        lines = self.table[1:]
+        fmted_rows = []
+        colwidths = self.table[0]
+        realwidths = colwidths[:]
+        separator = 0
+        # don't allow paragraphs in table cells for now
+        for line in lines:
+            if line == 'sep':
+                separator = len(fmted_rows)
+            else:
+                cells = []
+                for i, cell in enumerate(line):
+                    par = textwrap.wrap(cell, width=colwidths[i])
+                    if par:
+                        maxwidth = max(map(len, par))
+                    else:
+                        maxwidth = 0
+                    realwidths[i] = max(realwidths[i], maxwidth)
+                    cells.append(par)
+                fmted_rows.append(cells)
+
+        def writesep(char='-'):
+            out = ['+']
+            for width in realwidths:
+                out.append(char * (width + 2))
+                out.append('+')
+            self.add_text(''.join(out) + '\n')
+
+        def writerow(row):
+            lines = map(None, *row)
+            for line in lines:
+                out = ['|']
+                for i, cell in enumerate(line):
+                    if cell:
+                        out.append(' ' + cell.ljust(realwidths[i] + 1))
+                    else:
+                        out.append(' ' * (realwidths[i] + 2))
+                    out.append('|')
+                self.add_text(''.join(out) + '\n')
+
+        for i, row in enumerate(fmted_rows):
+            if separator and i == separator:
+                writesep('=')
+            else:
+                writesep('-')
+            writerow(row)
+        writesep('-')
+        self.table = None
+        self.end_state(wrap=False)
+
+    def visit_acks(self, node):
+        self.new_state(0)
+        self.add_text(', '.join(n.astext() for n in node.children[0].children) + '.')
+        self.end_state()
+        raise nodes.SkipNode
+
+    def visit_image(self, node):
+        self.add_text('[image]')
+        raise nodes.SkipNode
+
+    def visit_transition(self, node):
+        indent = sum(self.stateindent)
+        self.new_state(0)
+        self.add_text('=' * (MAXWIDTH - indent))
+        self.end_state()
+        raise nodes.SkipNode
+
+    def visit_bullet_list(self, node):
+        self._list_counter = -1
+
+    def depart_bullet_list(self, node):
+        pass
+
+    def visit_enumerated_list(self, node):
+        self._list_counter = 0
+
+    def depart_enumerated_list(self, node):
+        pass
+
+    def visit_definition_list(self, node):
+        self._list_counter = -2
+
+    def depart_definition_list(self, node):
+        pass
+
+    def visit_list_item(self, node):
+        if self._list_counter == -1:
+            # bullet list
+            self.new_state(2)
+        elif self._list_counter == -2:
+            # definition list
+            pass
+        else:
+            # enumerated list
+            self._list_counter += 1
+            self.new_state(len(str(self._list_counter)) + 2)
+
+    def depart_list_item(self, node):
+        if self._list_counter == -1:
+            self.end_state(first='* ', end=None)
+        elif self._list_counter == -2:
+            pass
+        else:
+            self.end_state(first='%s. ' % self._list_counter, end=None)
+
+    def visit_definition_list_item(self, node):
+        self._li_has_classifier = len(node) >= 2 and \
+                                  isinstance(node[1], nodes.classifier)
+
+    def depart_definition_list_item(self, node):
+        pass
+
+    def visit_term(self, node):
+        self.new_state(0)
+
+    def depart_term(self, node):
+        if not self._li_has_classifier:
+            self.end_state(end=None)
+
+    def visit_classifier(self, node):
+        self.add_text(' : ')
+
+    def depart_classifier(self, node):
+        self.end_state(end=None)
+
+    def visit_definition(self, node):
+        self.new_state()
+
+    def depart_definition(self, node):
+        self.end_state()
+
+    def visit_field_list(self, node):
+        pass
+
+    def depart_field_list(self, node):
+        pass
+
+    def visit_field(self, node):
+        pass
+
+    def depart_field(self, node):
+        pass
+
+    def visit_field_name(self, node):
+        self.new_state(0)
+
+    def depart_field_name(self, node):
+        self.add_text(':')
+        self.end_state(end=None)
+
+    def visit_field_body(self, node):
+        self.new_state()
+
+    def depart_field_body(self, node):
+        self.end_state()
+
+    def visit_centered(self, node):
+        pass
+
+    def depart_centered(self, node):
+        pass
+
+    def visit_admonition(self, node):
+        self.new_state(0)
+
+    def depart_admonition(self, node):
+        self.end_state()
+
+    def _visit_admonition(self, node):
+        self.new_state(2)
+
+    def _make_depart_admonition(name):
+        def depart_admonition(self, node):
+            self.end_state(first=admonitionlabels[name] + ': ')
+
+        return depart_admonition
+
+    visit_attention = _visit_admonition
+    depart_attention = _make_depart_admonition('attention')
+    visit_caution = _visit_admonition
+    depart_caution = _make_depart_admonition('caution')
+    visit_danger = _visit_admonition
+    depart_danger = _make_depart_admonition('danger')
+    visit_error = _visit_admonition
+    depart_error = _make_depart_admonition('error')
+    visit_hint = _visit_admonition
+    depart_hint = _make_depart_admonition('hint')
+    visit_important = _visit_admonition
+    depart_important = _make_depart_admonition('important')
+    visit_note = _visit_admonition
+    depart_note = _make_depart_admonition('note')
+    visit_tip = _visit_admonition
+    depart_tip = _make_depart_admonition('tip')
+    visit_warning = _visit_admonition
+    depart_warning = _make_depart_admonition('warning')
+
+    def visit_versionmodified(self, node):
+        self.new_state(0)
+        if node.children:
+            self.add_text(versionlabels[node['type']] % node['version'] + ': ')
+        else:
+            self.add_text(versionlabels[node['type']] % node['version'] + '.')
+
+    def depart_versionmodified(self, node):
+        self.end_state()
+
+    def visit_literal_block(self, node):
+        self.new_state()
+
+    def depart_literal_block(self, node):
+        self.end_state(wrap=False)
+
+    def visit_doctest_block(self, node):
+        self.new_state(0)
+
+    def depart_doctest_block(self, node):
+        self.end_state(wrap=False)
+
+    def visit_line_block(self, node):
+        self.new_state(0)
+
+    def depart_line_block(self, node):
+        self.end_state(wrap=False)
+
+    def visit_line(self, node):
+        pass
+
+    def depart_line(self, node):
+        pass
+
+    def visit_block_quote(self, node):
+        self.new_state()
+
+    def depart_block_quote(self, node):
+        self.end_state()
+
+    def visit_compact_paragraph(self, node):
+        pass
+
+    def depart_compact_paragraph(self, node):
+        pass
+
+    def visit_paragraph(self, node):
+        if not isinstance(node.parent, nodes.Admonition):
+            self.new_state(0)
+
+    def depart_paragraph(self, node):
+        if not isinstance(node.parent, nodes.Admonition):
+            self.end_state()
+
+    def visit_target(self, node):
+        raise nodes.SkipNode
+
+    def visit_index(self, node):
+        raise nodes.SkipNode
+
+    def visit_substitution_definition(self, node):
+        raise nodes.SkipNode
+
+    def visit_pending_xref(self, node):
+        pass
+
+    def depart_pending_xref(self, node):
+        pass
+
+    def visit_reference(self, node):
+        pass
+
+    def depart_reference(self, node):
+        pass
+
+    def visit_emphasis(self, node):
+        self.add_text('*')
+
+    def depart_emphasis(self, node):
+        self.add_text('*')
+
+    def visit_literal_emphasis(self, node):
+        self.add_text('*')
+
+    def depart_literal_emphasis(self, node):
+        self.add_text('*')
+
+    def visit_strong(self, node):
+        self.add_text('**')
+
+    def depart_strong(self, node):
+        self.add_text('**')
+
+    def visit_title_reference(self, node):
+        self.add_text('*')
+
+    def depart_title_reference(self, node):
+        self.add_text('*')
+
+    def visit_literal(self, node):
+        self.add_text('``')
+
+    def depart_literal(self, node):
+        self.add_text('``')
+
+    def visit_subscript(self, node):
+        self.add_text('_')
+
+    def depart_subscript(self, node):
+        pass
+
+    def visit_superscript(self, node):
+        self.add_text('^')
+
+    def depart_superscript(self, node):
+        pass
+
+    def visit_footnote_reference(self, node):
+        self.add_text('[%s]' % node.astext())
+        raise nodes.SkipNode
+
+    def visit_citation_reference(self, node):
+        self.add_text('[%s]' % node.astext())
+        raise nodes.SkipNode
+
+    def visit_Text(self, node):
+        self.add_text(node.astext())
+
+    def depart_Text(self, node):
+        pass
+
+    def visit_problematic(self, node):
+        self.add_text('>>')
+
+    def depart_problematic(self, node):
+        self.add_text('<<')
+
+    def visit_system_message(self, node):
+        self.new_state(0)
+        self.add_text('<SYSTEM MESSAGE: %s>' % node.astext())
+        self.end_state()
+        raise nodes.SkipNode
+
+    def visit_comment(self, node):
+        raise nodes.SkipNode
+
+    def visit_meta(self, node):
+        # only valid for HTML
+        raise nodes.SkipNode
+
+    def unknown_visit(self, node):
+        raise NotImplementedError('Unknown node: ' + node.__class__.__name__)
+
+text_writer = TextWriter()
+text_writer.translator_class = TextTranslator
+
+def to_plain_text(formatted_text):
+    w = TextWriter()
+    w.translator_class = TextTranslator
+    return publish_string(string,writer=_w)

--- a/redeem/gcodes/G2_G3.py
+++ b/redeem/gcodes/G2_G3.py
@@ -2,10 +2,14 @@
 GCode G2 and G3
 Circular movement
 
-Author: Elias Bakken
+Author: Andrew Mirsky
+email: andrew(at)mirskytech(dot)com
+Website: http://www.mirskytech.com
+License: GNU GPLv3 http://www.gnu.org/copyleft/gpl.html
 """
 
 from GCodeCommand import GCodeCommand
+
 try:
     from Path import Path, RelativePath, AbsolutePath
 except ImportError:
@@ -66,7 +70,37 @@ class G2(GCodeCommand):
         self.printer.path_planner.add_path(path)
    
     def get_description(self):
-        return ("Clockwise arc")
+        return "A circular or helical arc, clockwise"
+
+    def get_formatted_description(self):
+        return """Movement in a constant-radius arc; the plane of the arc is
+selected with ``G17`` (XY-plane), ``G18`` (XZ-plane) or ``G19`` (YZ-plane). The
+initial endpoint is defined as the current location at the beginning of the command.
+This command has two formats:
+
+- **Center Format**
+
+  The arc is also defined by: (1) second endpoint with coordinates within
+  the selected plane and (2) a center-point with an offset according
+  to the selected plane.
+
+- **Radius Format**
+
+  The arc is also defined by: (1) a second endpoint coordinates within the selected
+  plane and (2) a radius ``Rnnn`` which is positive to indicate the arc turns less than
+  180 degrees or negative to indicate the arc turns 180 degrees or more (up to 359.999 degrees). 
+        
+The axis that is perpendicular to the selected plane defines the *helical movement* for the arc command.
+
+============    ====================    =====================   ============
+Plane           Endpoint Coordinates    Center Format Offsets   Helical Axis
+============    ====================    =====================   ============
+XY (``G17``)    ``Xnnn Ynnn``           ``Innn Jnnn``           ``Znnn``
+XZ (``G18``)    ``Xnnn Znnn``           ``Innn Knnn``           ``Ynnn``
+YZ (``G19``)    ``Ynnn Znnn``           ``Jnnn Knnn``           ``Xnnn``
+============    ====================    =====================   ============
+
+"""
 
     def is_buffered(self):
         return True
@@ -83,6 +117,7 @@ class G2(GCodeCommand):
 class G02(G2):
     pass
 
+
 class G3(G2):
     def execute(self, g):
         path = self.execute_common(g)
@@ -91,9 +126,8 @@ class G3(G2):
         # Add the path. This blocks until the path planner has capacity
         self.printer.path_planner.add_path(path)
 
-
     def get_description(self):
-        return ("Counter-clockwise arc")
+        return "A circular or helical arc, counter-clockwise"
 
 
 # alias for G3, since some CAD/CAM generate with leading zero

--- a/redeem/gcodes/GCodeCommand.py
+++ b/redeem/gcodes/GCodeCommand.py
@@ -8,10 +8,8 @@ License: CC BY-SA: http://creativecommons.org/licenses/by-sa/2.0/
 """
 
 from abc import ABCMeta, abstractmethod
-
 from docutils.core import publish_string
-
-from TextWriter import text_writer
+from redeem.TextWriter import text_writer
 
 
 class GCodeCommand(object):

--- a/redeem/gcodes/GCodeCommand.py
+++ b/redeem/gcodes/GCodeCommand.py
@@ -9,6 +9,10 @@ License: CC BY-SA: http://creativecommons.org/licenses/by-sa/2.0/
 
 from abc import ABCMeta, abstractmethod
 
+from docutils.core import publish_string
+
+from TextWriter import text_writer
+
 
 class GCodeCommand(object):
     __metaclass__ = ABCMeta
@@ -26,8 +30,16 @@ class GCodeCommand(object):
         pass
 
     def get_long_description(self):
-        # Return short description if long description is missing
+        """Override method to provide long description as text."""
+        # Return formatted description as plain text
+        if not self.get_formatted_description():
+            return publish_string(self.get_formatted_description(), writer=text_writer)
+        # If subclass doesn't override, return standard description
         return self.get_description()
+
+    def get_formatted_description(self):
+        """ Override method to return a full description formatted as restructured text."""
+        return None
 
     def is_buffered(self):
         """ Return true if the command has to wait in the command buffer or

--- a/redeem/gcodes/M23.py
+++ b/redeem/gcodes/M23.py
@@ -11,70 +11,88 @@ from GCodeCommand import GCodeCommand
 
 import ctypes
 import os
-
 import parted
+import logging
+
+from sh import mount, ErrorReturnCode_32
+from thread import start_new_thread
 
 from redeem.Gcode import Gcode
 
+"""
+auto - this is a special one. It will try to guess the fs type when you use this.
+ext4 - this is probably the most common Linux fs type of the last few years
+ext3 - this is the most common Linux fs type from a couple years back
+ntfs - this is the most common Windows fs type or larger external hard drives
+vfat - this is the most common fs type used for smaller external hard drives
+exfat - is also a file system option commonly found on USB flash drives and other external drives
+"""
 
 class M23(GCodeCommand):
 
     @staticmethod
-    def mount(source, target, fs, options=''):
-        ret = ctypes.CDLL('libc.so.6', use_errno=True).mount(source, target, fs, 0, options)
-        if ret < 0:
-            errno = ctypes.get_errno()
-            raise RuntimeError("Error mounting {} ({}) on {} with options '{}': {}".
-                               format(source, fs, target, options, os.strerror(errno)))
+    def mount(g, source, target, fstype=None, options=''):
 
-    def execute(self, g):
+        try:
+            ret = mount(source, target)
+        except ErrorReturnCode_32:
+            g.printer.send_message(g.prot, "could not mount: {} to {} - {}".format(source, target, ret))
 
-        device_location = '/dev/mmcblk0p1'
-        mount_location = '/media/sdcard'
+    def process_gcode(self, g, fn):
 
-        if not os.path.ismount(mount_location):
-
-            fstype = 'exfat'
-
-            # check to see if there is a device available for reading
-            device = parted(device_location)
-            disk = parted.newDisk(device)
-
-            if disk.type == 'msdos':
-                fstype = 'msdos'
-            elif disk.type == 'vfat':
-                fstype = 'vfat'
-
-            self.mount(device_location, mount_location, fstype, 'r')
-
-        if not os.path.ismount(mount_location):
-            self.printer.send_message("could not mount device '{}'".format(device_location))
-            return
-
-        text = g.get_message()[len("M23"):]
-        fn = os.path.join(mount_location, text.strip())
+        logging.info("M23: starting gcode file processing")
 
         if not os.path.exists(fn):
-            self.printer.send_message("could not find file at '{}'".format(fn))
+            self.printer.send_message(g.prot, "could not find file at '{}'".format(fn))
             return
 
         with open(fn, 'r') as gcode_file:
+            logging.info("M23: file open")
 
             for line in gcode_file:
-
                 line = line.strip()
                 if not line or line.startswith(';'):
                     continue
-
                 file_g = Gcode({"message": line, "parent": g})
                 self.printer.processor.execute(file_g)
+
+        logging.info("M23: file complete")
+
+    def execute(self, g):
+
+        # device_location = '/dev/mmcblk1p1'
+        device_location = '/dev/sda1'
+        mount_location = '/media/usbmem'
+
+        if not os.path.isdir(mount_location):
+            os.mkdir(mount_location)
+
+        if not os.path.ismount(mount_location):
+
+            self.mount(g, device_location, mount_location)
+
+        if not os.path.ismount(mount_location):
+            self.printer.send_message(g.prot, "could not mount device '{}'".format(device_location))
+            return
+
+        text = g.get_message()[len("M23"):]
+
+        if not text.strip():
+            self.printer.send_message(g.prot, "missing filename")
+            return
+
+        fn = os.path.join(mount_location, text.strip())
+
+        start_new_thread(self.process_gcode, (g, fn))
 
     def get_description(self):
         return """"Select a file from the SD Card"""
 
     def get_formatted_description(self):
         return """
-Load *and begin printing* a gcode file from an sdcard.
+Load *and begin printing* a gcode file from a usb memory stick.
+``M23 circle.gcode``
+``M32 afoldername/circle.gcode``
         """
 
     def is_buffered(self):

--- a/redeem/gcodes/M23.py
+++ b/redeem/gcodes/M23.py
@@ -1,0 +1,81 @@
+"""
+GCode M23
+Select SD file
+
+Author: Andrew Mirsky
+email: andrew@mirskytech.com
+License: CC BY-SA: http://creativecommons.org/licenses/by-sa/2.0/
+"""
+
+from GCodeCommand import GCodeCommand
+
+import ctypes
+import os
+
+import parted
+
+from redeem.Gcode import Gcode
+
+
+class M23(GCodeCommand):
+
+    @staticmethod
+    def mount(source, target, fs, options=''):
+        ret = ctypes.CDLL('libc.so.6', use_errno=True).mount(source, target, fs, 0, options)
+        if ret < 0:
+            errno = ctypes.get_errno()
+            raise RuntimeError("Error mounting {} ({}) on {} with options '{}': {}".
+                               format(source, fs, target, options, os.strerror(errno)))
+
+    def execute(self, g):
+
+        device_location = '/dev/mmcblk0p1'
+        mount_location = '/media/sdcard'
+
+        if not os.path.ismount(mount_location):
+
+            fstype = 'exfat'
+
+            # check to see if there is a device available for reading
+            device = parted(device_location)
+            disk = parted.newDisk(device)
+
+            if disk.type == 'msdos':
+                fstype = 'msdos'
+            elif disk.type == 'vfat':
+                fstype = 'vfat'
+
+            self.mount(device_location, mount_location, fstype, 'r')
+
+        if not os.path.ismount(mount_location):
+            self.printer.send_message("could not mount device '{}'".format(device_location))
+            return
+
+        text = g.get_message()[len("M23"):]
+        fn = os.path.join(mount_location, text.strip())
+
+        if not os.path.exists(fn):
+            self.printer.send_message("could not find file at '{}'".format(fn))
+            return
+
+        with open(fn, 'r') as gcode_file:
+
+            for line in gcode_file:
+
+                line = line.strip()
+                if not line or line.startswith(';'):
+                    continue
+
+                file_g = Gcode({"message": line, "parent": g})
+                self.printer.processor.execute(file_g)
+
+    def get_description(self):
+        return """"Select a file from the SD Card"""
+
+    def get_formatted_description(self):
+        return """
+Load *and begin printing* a gcode file from an sdcard.
+        """
+
+    def is_buffered(self):
+        return False

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ INSTALL_REQUIRES = [
     "sympy",
     "docutils",
     "python-smbus",
+    "sh",
     "mock"
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ INSTALL_REQUIRES = [
     "scipy",
     "numpy",
     "sympy",
+    "docutils",
     "python-smbus",
     "mock"
 ]


### PR DESCRIPTION
Following Marlin's usage of `M23`: https://github.com/MarlinFirmware/Marlin/wiki/M23

Load gcode directly from file and run. Currently implemented using the USB host port; using the sdcard is problematic because if the card remains inserted on system startup, it tries (and fails) to boot from the sdcard. Also, on the BBB, the sdcard is a different device name depending on which board; usb is consistently set as `/dev/sda1`.

The implementation uses a thread to process lines from the file allowing other gcodes to be inserted in the stream (such as `M24` & `M25` for starting and pausing or M105's for temperature). All output from commands in the file will (such as alarms) will be reported back to the communications interface on which the original `M23` was initiated.