### PR TITLE
python 2/3 support: print and except statements

### DIFF
--- a/redeem/BedCompensation.py
+++ b/redeem/BedCompensation.py
@@ -137,13 +137,13 @@ if __name__ == "__main__":
     ax.set_ylabel('Y')
     ax.set_zlabel('Z')
 
-    print "Level bed max diff before: "+str(max(z1)-min(z1))+" after: "+str(max(z3)-min(z3))
+    print("Level bed max diff before: "+str(max(z1)-min(z1))+" after: "+str(max(z3)-min(z3)))
 
-    print "var matrix = "+json.dumps(Rn.tolist())+";"
+    print("var matrix = "+json.dumps(Rn.tolist())+";")
     probe = {"x": x1, "y": y1, "z": z1}
-    print "var probe = "+json.dumps(probe)+";"
+    print("var probe = "+json.dumps(probe)+";")
     fixed = {"x": x3, "y": y3, "z": z3}
-    print "var fixed = "+json.dumps(fixed)+";"   
+    print("var fixed = "+json.dumps(fixed)+";")
 
     plt.show()
     

--- a/redeem/CascadingConfigParser.py
+++ b/redeem/CascadingConfigParser.py
@@ -186,4 +186,4 @@ if __name__ == '__main__':
                     format='%(asctime)s %(name)-12s %(levelname)-8s %(message)s',
                     datefmt='%m-%d %H:%M')
     c = CascadingConfigParser(["/etc/redeem/default.cfg", "/etc/redeem/printer.cfg", "/etc/redeem/local.cfg"])
-    print c.get_default_settings()
+    print(c.get_default_settings())

--- a/redeem/EndStop.py
+++ b/redeem/EndStop.py
@@ -110,27 +110,24 @@ class EndStop:
             self.printer.comms["octoprint"].send_message("End stop {} hit!".format(self.name))
     
 if __name__ == "__main__":
-    print "Test endstops"
+    print("Test endstops")
     
     import time
     
     while True:
         state = PruInterface.get_shared_long(0)
-        print bin(state) + "  ", 
+        print(bin(state) + "  ",)
         if bool(state & (1 << 0)):
-            print "X1",
+            print("X1",)
         elif bool(state & (1 << 1)):
-            print "Y1",
+            print("Y1",)
         elif bool(state & (1 << 2)):
-            print "Z1",
+            print("Z1",)
         elif bool(state & (1 << 3)):
-            print "X2",
+            print("X2",)
         elif bool(state & (1 << 4)):
-            print "Y2",
+            print("Y2",)
         elif bool(state & (1 << 5)):
-            print "Z2",
-        print (" "*30)+"\r",
+            print("Z2",)
+        print((" "*30)+"\r",)
         time.sleep(0.01)
-        
-            
-    

--- a/redeem/Ethernet.py
+++ b/redeem/Ethernet.py
@@ -78,7 +78,7 @@ class Ethernet:
         try:
             if self.client:
                 self.client.send(message)
-        except socket.error, (value, message):
+        except socket.error as (value, message):
             logging.error("Ethernet " + message)
 
     def read_line(self):
@@ -87,7 +87,7 @@ class Ethernet:
         while self.running:
             try:
                 char = self.client.recv(1)
-            except socket.error, (value, message):
+            except socket.error as (value, message):
                 logging.error("Ethernet " + message)
                 char = ""
             if char == "":

--- a/redeem/GCodeProcessor.py
+++ b/redeem/GCodeProcessor.py
@@ -104,7 +104,7 @@ class GCodeProcessor:
         try:
             self.gcodes[val].on_sync(gcode)
             # Forcefully check/set the readyEvent here?
-        except Exception, e:
+        except Exception as e:
             logging.error("Error while executing "+gcode.code()+": "+str(e))
         return gcode
 
@@ -126,7 +126,7 @@ class GCodeProcessor:
             #if self.gcodes[val].is_sync():
             #    self.gcodes[val].readyEvent.wait()  # Block until the event has occurred.
 
-        except Exception, e:
+        except Exception as e:
             logging.error("Error while executing "+gcode.code()+": "+str(e))
             logging.error(traceback.format_exc(sys.exc_info()[2]))
         return gcode
@@ -158,7 +158,7 @@ class GCodeProcessor:
             return "GCode " + gcode.code() + " is not implemented"
         try:
             return self.gcodes[val].get_long_description()
-        except Exception, e:
+        except Exception as e:
             logging.error("Error while getting long description on "+gcode.code()+": "+str(e))
         return "Error getting long decription for "+str(val)
 
@@ -176,8 +176,8 @@ if __name__ == '__main__':
 
     proc = GCodeProcessor({})
 
-    print ""
-    print "Commands:"
+    print("")
+    print("Commands:")
 
     descriptions = proc.get_supported_commands_and_description()
 
@@ -187,4 +187,4 @@ if __name__ == '__main__':
                 s for s in re.split(r'(\d+)', string_)]
 
     for name in sorted(descriptions, key=_natural_key):
-        print name + "\t" + descriptions[name]
+        print(name + "\t" + descriptions[name])

--- a/redeem/Gcode.py
+++ b/redeem/Gcode.py
@@ -41,9 +41,7 @@ class Gcode:
                 self.prot = self.parent.prot if self.parent else "None"
             self.has_crc = False
             self.answer = "ok"
-            #print packet
             if len(self.message) == 0:
-                #print packet
                 #logging.debug("Empty message")
                 self.gcode = "No-Gcode"
                 return

--- a/redeem/PathPlanner.py
+++ b/redeem/PathPlanner.py
@@ -37,7 +37,7 @@ import traceback
 
 try:
     from path_planner.PathPlannerNative import PathPlannerNative, AlarmCallbackNative
-except Exception, e:
+except Exception as e:
     try:
         from _PathPlannerNative import PathPlannerNative, AlarmCallbackNative
     except:
@@ -519,7 +519,7 @@ if __name__ == '__main__':
          133.33333333 * (2 ** 4) * 1000.0, 33.4375 * (2 ** 4) * 1000.0,
          33.4375 * (2 ** 4) * 1000.0])
 
-    print "Making steppers"
+    print("Making steppers")
 
     steppers = {}
 

--- a/redeem/PluginsController.py
+++ b/redeem/PluginsController.py
@@ -111,7 +111,7 @@ if __name__ == '__main__':
                         format='%(asctime)s %(name)-12s %(levelname)-8s %(message)s',
                         datefmt='%m-%d %H:%M')
 
-    print "Available plugins:"
+    print("Available plugins:")
 
     descriptions = PluginsController.get_supported_plugins_and_description()
 
@@ -121,4 +121,4 @@ if __name__ == '__main__':
                 s for s in re.split(r'(\d+)', string_)]
 
     for name in sorted(descriptions, key=_natural_key):
-        print name + "\t\t" + descriptions[name]
+        print(name + "\t\t" + descriptions[name])

--- a/redeem/Stepper.py
+++ b/redeem/Stepper.py
@@ -472,8 +472,8 @@ class Stepper_00A3(Stepper_00A4):
 if __name__ == '__main__':
     s = Stepper("GPIO0_27", "GPIO1_29", "GPIO2_4" , 0, 0, "X")
 
-    print s.get_step_pin()
-    print s.get_step_bank()
-    print s.get_dir_pin()
-    print s.get_dir_bank()
+    print(s.get_step_pin())
+    print(s.get_step_bank())
+    print(s.get_dir_pin())
+    print(s.get_dir_bank())
 

--- a/redeem/TextWriter.py
+++ b/redeem/TextWriter.py
@@ -121,7 +121,7 @@ class TextTranslator(nodes.NodeVisitor):
         # XXX header/footer?
 
     def visit_highlightlang(self, node):
-        raise nodes.SkipNode
+        raise nodes.SkipNode()
 
     def visit_section(self, node):
         self._title_char = self.sectionchars[self.sectionlevel]
@@ -162,7 +162,7 @@ class TextTranslator(nodes.NodeVisitor):
     def visit_title(self, node):
         if isinstance(node.parent, nodes.Admonition):
             self.add_text(node.astext() + ': ')
-            raise nodes.SkipNode
+            raise nodes.SkipNode()
         self.new_state(0)
 
     def depart_title(self, node):
@@ -191,7 +191,7 @@ class TextTranslator(nodes.NodeVisitor):
             self.new_state(0)
             self.add_text('Platform: {}}'.format(node['platform']))
             self.end_state()
-        raise nodes.SkipNode
+        raise nodes.SkipNode()
 
     def visit_desc(self, node):
         pass
@@ -239,7 +239,7 @@ class TextTranslator(nodes.NodeVisitor):
         else:
             self.first_param = 0
         self.add_text(node.astext())
-        raise nodes.SkipNode
+        raise nodes.SkipNode()
 
     def visit_desc_optional(self, node):
         self.add_text('[')
@@ -292,7 +292,7 @@ class TextTranslator(nodes.NodeVisitor):
                 self.add_text('%s    ' % (' ' * len(lastname)))
             self.add_text(production.astext() + '\n')
         self.end_state(wrap=False)
-        raise nodes.SkipNode
+        raise nodes.SkipNode()
 
     def visit_seealso(self, node):
         self.new_state()
@@ -318,7 +318,7 @@ class TextTranslator(nodes.NodeVisitor):
         self.end_state(first='[%s] ' % self._citlabel)
 
     def visit_label(self, node):
-        raise nodes.SkipNode
+        raise nodes.SkipNode()
 
     # XXX: option list could use some better styling
 
@@ -368,11 +368,11 @@ class TextTranslator(nodes.NodeVisitor):
         pass
 
     def visit_tabular_col_spec(self, node):
-        raise nodes.SkipNode
+        raise nodes.SkipNode()
 
     def visit_colspec(self, node):
         self.table[0].append(node['colwidth'])
-        raise nodes.SkipNode
+        raise nodes.SkipNode()
 
     def visit_tgroup(self, node):
         pass
@@ -400,8 +400,7 @@ class TextTranslator(nodes.NodeVisitor):
 
     def visit_entry(self, node):
         if node.has_key('morerows') or node.has_key('morecols'):
-            raise NotImplementedError('Column or row spanning cells are '
-                                      'not implemented.')
+            raise NotImplementedError('Column or row spanning cells are not implemented.')
         self.new_state(0)
 
     def depart_entry(self, node):
@@ -470,18 +469,18 @@ class TextTranslator(nodes.NodeVisitor):
         self.new_state(0)
         self.add_text(', '.join(n.astext() for n in node.children[0].children) + '.')
         self.end_state()
-        raise nodes.SkipNode
+        raise nodes.SkipNode()
 
     def visit_image(self, node):
         self.add_text('[image]')
-        raise nodes.SkipNode
+        raise nodes.SkipNode()
 
     def visit_transition(self, node):
         indent = sum(self.stateindent)
         self.new_state(0)
         self.add_text('=' * (MAXWIDTH - indent))
         self.end_state()
-        raise nodes.SkipNode
+        raise nodes.SkipNode()
 
     def visit_bullet_list(self, node):
         self._list_counter = -1
@@ -667,13 +666,13 @@ class TextTranslator(nodes.NodeVisitor):
             self.end_state()
 
     def visit_target(self, node):
-        raise nodes.SkipNode
+        raise nodes.SkipNode()
 
     def visit_index(self, node):
-        raise nodes.SkipNode
+        raise nodes.SkipNode()
 
     def visit_substitution_definition(self, node):
-        raise nodes.SkipNode
+        raise nodes.SkipNode()
 
     def visit_pending_xref(self, node):
         pass
@@ -731,11 +730,11 @@ class TextTranslator(nodes.NodeVisitor):
 
     def visit_footnote_reference(self, node):
         self.add_text('[%s]' % node.astext())
-        raise nodes.SkipNode
+        raise nodes.SkipNode()
 
     def visit_citation_reference(self, node):
         self.add_text('[%s]' % node.astext())
-        raise nodes.SkipNode
+        raise nodes.SkipNode()
 
     def visit_Text(self, node):
         self.add_text(node.astext())
@@ -753,14 +752,14 @@ class TextTranslator(nodes.NodeVisitor):
         self.new_state(0)
         self.add_text('<SYSTEM MESSAGE: %s>' % node.astext())
         self.end_state()
-        raise nodes.SkipNode
+        raise nodes.SkipNode()
 
     def visit_comment(self, node):
-        raise nodes.SkipNode
+        raise nodes.SkipNode()
 
     def visit_meta(self, node):
         # only valid for HTML
-        raise nodes.SkipNode
+        raise nodes.SkipNode()
 
     def unknown_visit(self, node):
         raise NotImplementedError('Unknown node: ' + node.__class__.__name__)

--- a/redeem/plugins/VCNL4000Plugin.py
+++ b/redeem/plugins/VCNL4000Plugin.py
@@ -49,11 +49,11 @@ class VCNL4000(object):
         val = 0
         i = 0
         state = self.i2c.readU8(0x80)
-        print state
+        print(state)
         self.i2c.write8(0x80, (1<<3))
         while True:
             state = self.i2c.readU8(0x80)
-            print state
+            print(state)
             if (state & (1 << 5)) or i > 100:
                 val |= (self.i2c.readU8(0x87) << 8)
                 val |= (self.i2c.readU8(0x88) << 0)
@@ -87,6 +87,6 @@ if __name__ == '__main__':
 
     prox = VCNL4000()
     for i in range(100):
-        print prox.get_distance()
-        #print prox.get_ambient()
+        print(prox.get_distance())
+        #print(prox.get_ambient())
         #time.sleep(0.1)


### PR DESCRIPTION
while python 2.7 is still going to be supported for another 2 years, there are python 3 features that could help in development. most python 3 changes can be made in a backwards compatible way with python 2.7.  smaller pull requests focusing on specific classes of changes is probably more approachable; this one focuses on migrating `print` and `except` syntax changes. 

for reference: 
- http://python-future.org/compatible_idioms.html#print
- http://python-future.org/compatible_idioms.html#catching-exceptions 