### PR TITLE
arc command unit tests fix

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 docutils==0.14
-python-smbus
 funcsigs==1.0.2
 git+https://github.com/adafruit/Adafruit_Python_GPIO.git#egg=adafruit_gpio
 mock==2.0.0
@@ -8,7 +7,6 @@ pbr==3.1.1
 py==1.4.34
 pytest==3.1.2
 pyusb==1.0.0
-scipy==0.19.0
 six==1.10.0
 sh==1.12.14
 spidev==3.2.0

--- a/tests/gcode/MockPrinter.py
+++ b/tests/gcode/MockPrinter.py
@@ -16,7 +16,8 @@ sys.modules['redeem.DAC'] = mock.Mock()
 sys.modules['redeem.ShiftRegister.py'] = mock.Mock()
 sys.modules['Adafruit_BBIO'] = mock.Mock()
 sys.modules['Adafruit_BBIO.GPIO'] = mock.Mock()
-sys.modules['Adafruit_I2C'] = mock.Mock()
+sys.modules['Adafruit_GPIO'] = mock.Mock()
+sys.modules['Adafruit_GPIO.I2C'] = mock.Mock()
 sys.modules['redeem.StepperWatchdog'] = mock.Mock()
 sys.modules['redeem.StepperWatchdog.GPIO'] = mock.Mock()
 sys.modules['redeem._PathPlannerNative'] = mock.Mock()
@@ -29,6 +30,9 @@ sys.modules['JoinableQueue'] = mock.Mock()
 sys.modules['redeem.USB'] = mock.Mock()
 sys.modules['redeem.Ethernet'] = mock.Mock()
 sys.modules['redeem.Pipe'] = mock.Mock()
+sys.modules['redeem.Fan'] = mock.Mock()
+sys.modules['redeem.Mosfet'] = mock.Mock()
+sys.modules['redeem.PWM'] = mock.Mock()
 
 from redeem.CascadingConfigParser import CascadingConfigParser
 from redeem.Redeem import *
@@ -84,16 +88,12 @@ log_to_file = False
     @classmethod
     @mock.patch.object(EndStop, "_wait_for_event", new=None)
     @mock.patch.object(PathPlanner, "_init_path_planner")
-    @mock.patch.object(CascadingConfigParser, "get_key")
     @mock.patch("redeem.CascadingConfigParser", new=CascadingConfigParserWedge)
-    def setUpClass(cls, mock_get_key, mock_init_path_planner):
-
-        mock_get_key.return_value = "TESTING_DUMMY_KEY"
+    def setUpClass(cls, mock_init_path_planner):
 
         """
         Allow Extruder or HBP instantiation without crashing 'cause not BBB/Replicape
         """
-        # class DisabledExtruder(Extruder):
         def disabled_extruder_enable(self):
             self.avg = 1
             self.temperatures = [100]
@@ -110,6 +110,7 @@ log_to_file = False
 
         cls.R = Redeem(config_location=cfg_path)
         cls.printer = cls.R.printer
+        cls.printer.replicape_key = "TESTING_DUMMY_KEY"
 
         cls.setUpPatch()
 

--- a/tests/gcode/MockPrinter.py
+++ b/tests/gcode/MockPrinter.py
@@ -102,8 +102,12 @@ log_to_file = False
         def disabled_hbp_enable(self):
             pass
 
+        def bypass_init_path_planner(self):
+            pass
+
         mock.patch('redeem.Extruder.Extruder.enable', new=disabled_extruder_enable).start()
         mock.patch('redeem.Extruder.HBP.enable', new=disabled_hbp_enable).start()
+        mock.patch('redeem.PathPlanner.PathPlanner._init_path_planner', new=bypass_init_path_planner)
 
         cfg_path = "../configs"
         cls.setUpConfigFiles(cfg_path)

--- a/tests/gcode/test_G2_G3.py
+++ b/tests/gcode/test_G2_G3.py
@@ -24,7 +24,8 @@ class G2G3CircleTests(MockPrinter):
 
     @classmethod
     def setUpPatch(cls):
-        cls.printer.path_planner.native_planner = Mock()
+        attrs = {'getLastQueueMoveStatus.return_value': False}
+        cls.printer.path_planner.native_planner = Mock(**attrs)
         cls.printer.ensure_steppers_enabled = Mock()
 
     def setUp(self):
@@ -267,7 +268,8 @@ class G2G3ExtrusionTests(MockPrinter):
 
     @classmethod
     def setUpPatch(cls):
-        cls.printer.path_planner.native_planner = Mock()
+        attrs = {'getLastQueueMoveStatus.return_value': False}
+        cls.printer.path_planner.native_planner = Mock(**attrs)
         cls.printer.ensure_steppers_enabled = Mock()
 
     def setUp(self):


### PR DESCRIPTION
Relative imports broke the arc command tests, needed to add a mock to the native planner mock.