### PR TITLE
Default fan speed

### DIFF
--- a/configs/default.cfg
+++ b/configs/default.cfg
@@ -261,17 +261,19 @@ cooler_0_target_temp = 60
 # therm-e-fan-0-target_temp = 70
 
 [Fans]
-default-fan-0-value = 0.0
-default-fan-1-value = 0.0
-default-fan-2-value = 0.0
-default-fan-3-value = 0.0
-default-fan-3-value = 0.0
-default-fan-4-value = 0.0
-default-fan-5-value = 0.0
-default-fan-6-value = 0.0
-default-fan-7-value = 0.0
-default-fan-8-value = 0.0
-default-fan-9-value = 0.0
+
+# default fan values in range 0..255
+default-fan-0-value = 0
+default-fan-1-value = 0
+default-fan-2-value = 0
+default-fan-3-value = 0
+default-fan-3-value = 0
+default-fan-4-value = 0
+default-fan-5-value = 0
+default-fan-6-value = 0
+default-fan-7-value = 0
+default-fan-8-value = 0
+default-fan-9-value = 0
 
 [Heaters]
 # For list of available temp charts, look in temp_chart.py

--- a/redeem/Redeem.py
+++ b/redeem/Redeem.py
@@ -332,7 +332,8 @@ class Redeem:
 
         # Set default value for all fans
         for i, f in enumerate(self.printer.fans):
-            f.set_value(self.printer.config.getfloat('Fans', "default-fan-{}-value".format(i)))
+            val = self.printer.config.getint('Fans', "default-fan-{}-value".format(i))
+            f.set_value(val/255.0)
 
         # Init the servos
         printer.servos = []


### PR DESCRIPTION
Modification to the setting of default fan speeds in config to follow the style used in gcode i.e. use an integer in the range 0..255 rather than a float in the range 0..1