### PR TITLE
SD printing: un-buffered

### DIFF
--- a/redeem/SDCardManager.py
+++ b/redeem/SDCardManager.py
@@ -1,10 +1,15 @@
 from multiprocessing import Lock
+import os
 
+def blocks(files, size=65536):
+    while True:
+        b = files.read(size)
+        if not b: break
+        yield b
 
 class SDCardManager(object):
     file_name = None
-    lines = []
-    lines_size = []
+    gcode_file = None
     byte_count = None
     line_count = None
     file_byte_size = None
@@ -20,57 +25,68 @@ class SDCardManager(object):
 
     def load_file(self, f):
         """
-        read the file in as a list of lines
+        open the file, remains open until another file is opened
         """
+
+        self.lock.acquire()
+        
+        self.file_name = f
+        
+        if self.gcode_file:
+            self.gcode_file.close()
             
-        with open(f, 'r') as gcode_file:
-
-            self.lock.acquire()
-            self.file_name = f
-            self.line_count = 0
-            self.byte_count = 0
-            self.file_byte_size = 0
-            self.file_line_size = 0
-            self.lines = []
-            self.lines_size = []
-            self.lock.release()
-
-            gcode_file.seek(0)
-
-            for line in gcode_file:
-                self.lock.acquire()
-                self.file_line_size += 1
-                self.file_byte_size += len(line.encode('utf-8'))
-                self.lines.append(line)
-                self.lines_size.append(self.file_byte_size) # cumulative sum of bytes
-                self.lock.release()
+        self.gcode_file = open(self.file_name, 'r')
+        
+        self.line_count = 0
+        self.byte_count = 0
+        
+        # file size in bytes
+        self.file_byte_size = os.path.getsize(self.file_name)
+        
+        # file size in lines
+        self.file_line_size = sum(bl.count("\n") for bl in blocks(self.gcode_file))
+        self.gcode_file.seek(-1, 2)
+        end = self.gcode_file.read()
+        if end != "\n":
+            self.file_line_size += 1
             
-            return True
+        #reset file position
+        self.gcode_file.seek(0)
+        
+        self.lock.release()
+            
+        return True
             
     def next(self):
         """
-        return the next line in the list and increment counters
+        return the next line in the file and increment counters
         """
         
         self.lock.acquire()
         lc = self.line_count
         N = self.file_line_size
-        status = self.active
+        active = self.active
         self.lock.release()
         
-        if (lc < N) and status:
+        if not active:
+            raise StopIteration()
+            return
+        
+        if (lc < N):
             self.lock.acquire()
-            out = self.lines[self.line_count]
-            self.byte_count = self.lines_size[self.line_count]
+            line = self.gcode_file.readline()
+            self.byte_count += len(line.encode('utf-8'))
             self.line_count += 1
             self.lock.release()
-            return out
+            return line
         else:
             self.lock.acquire()
-            self.byte_count = self.lines_size[-1]
+            self.byte_count = self.file_byte_size
             self.line_count = N
             self.lock.release()
             raise StopIteration()
+            
+        return
             
     def get_file_size(self):
         """
@@ -119,9 +135,9 @@ class SDCardManager(object):
         
         return st
         
-    def set_active(self, status):
+    def set_status(self, status):
         """
-        get the status of the current file
+        set the status of the current file
         """
         
         self.lock.acquire()
@@ -139,17 +155,30 @@ class SDCardManager(object):
         will be converted to a line position
         """
         
-        if byte_position > 0:
-            self.lock.acquire()
-            szs = self.lines_size
-            self.lock.release()
-            for i, b in enumerate(szs):
-                if byte_position < b:
-                    line_position = i
-                    byte_position = b
-                    break
-        
         self.lock.acquire()
+        
+        # reset file object
+        self.gcode_file.seek(0)
+        
+        # walk through the file line by line until we find a location that
+        # matches either line position or byte count
+        if (byte_position > 0) or (line_position > 0):
+            
+            i = 0; b = 0
+            for line in self.gcode_file:
+                ls = len(line.encode('utf-8'))
+                if (byte_position > 0) and (byte_position < b+ls):
+                    break
+                elif (line_position > 0) and (line_position == i):
+                    break
+                    
+                i += 1
+                b += ls
+                
+            line_position = i
+            byte_position = b
+        
+
         self.line_count = line_position
         self.byte_count = byte_position
         self.lock.release()
@@ -163,8 +192,6 @@ class SDCardManager(object):
         """
         
         self.file_name = None
-        self.lines = []
-        self.lines_size = []
         self.byte_count = None
         self.line_count = None
         self.file_byte_size = None

--- a/redeem/gcodes/M2x.py
+++ b/redeem/gcodes/M2x.py
@@ -281,6 +281,7 @@ class M23(M2X):
 
         self.printer.send_message(g.prot, "File opened:{} Lines:{} Size:{}B".format(fn, nl, nb))
         self.printer.send_message(g.prot, "File selected")
+        logging.info("M23: finished gcode file processing")
 
 
     def get_description(self):
@@ -302,7 +303,7 @@ class M24(GCodeCommand):
 
     def process_gcode(self, g):
         
-        self.printer.sd_card_manager.set_active(True)
+        self.printer.sd_card_manager.set_status(True)
 
         for line in self.printer.sd_card_manager:
             line = line.strip()
@@ -313,7 +314,7 @@ class M24(GCodeCommand):
             
         if self.printer.sd_card_manager.get_status():
             logging.info("M24: file complete")
-        self.printer.sd_card_manager.set_active(False)
+        self.printer.sd_card_manager.set_status(False)
         
         self.printer.send_message(g.prot, "Done printing file")
 
@@ -327,7 +328,10 @@ class M24(GCodeCommand):
             start_new_thread(self.process_gcode, (g, ))
             
             # allow some time for the new thread to start before we proceed
-            sleep(0.1)
+            counter = 0
+            while (not active) and (counter < 10):
+                sleep(0.1)
+                counter += 1
 
         self.printer.path_planner.resume()
         
@@ -348,7 +352,7 @@ If the current print (from any source) was paused by ``M25``, this will resume t
 class M25(GCodeCommand):
 
     def execute(self, g):
-        self.printer.sd_card_manager.set_active(False)
+        self.printer.sd_card_manager.set_status(False)
 
     def get_description(self):
         return "Pause the current SD print."


### PR DESCRIPTION
Read lines directly from the selected file into the path planner rather than pre-buffering the entire file. Should speed up M23 significantly for larger files. 

These changes should be checked by someone who has a print that requires rapid data transfer to verify that this approach still works. Unfortunately I don't have such a file on-hand. Otherwise a smaller ring buffer will have to be implemented as suggested by @goeland86. 