### PR TITLE
fix build on GCC 7.x

### DIFF
--- a/redeem/path_planner/PruTimer.h
+++ b/redeem/path_planner/PruTimer.h
@@ -16,6 +16,7 @@
 #include <string.h>
 #include <strings.h>
 #include <condition_variable>
+#include <functional>
 #include "Logger.h"
 
 //#define DEMO_PRU


### PR DESCRIPTION
std::function is used but _functional_ header is not included.
Latest stable GCC requires this header to use it.