### PR TITLE
fix setup.py so the python files get installed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,7 @@ import versioneer
 
 setup(
     name="Redeem",
+    packages=find_packages(exclude=["redeem/path_planner"]),
     version=versioneer.get_version(),
     cmdclass=versioneer.get_cmdclass(),
     data_files=[


### PR DESCRIPTION
It looks like detecting the python files to install was removed in
6c3d83146d0c9e01c64d25efd35518812550deb3 . This change adds it back
so `python setup.py install` installs them.