### PR TITLE
Initialize gpio with overlay

### DIFF
--- a/redeem/Stepper.py
+++ b/redeem/Stepper.py
@@ -60,11 +60,8 @@ class Stepper(object):
         # terrible hack to cover a bug in Adafruit
         dir_name = "EHRPWM2A" if dir_pin == "GPIO0_22" else dir_pin
 
-        try:
-            GPIO.setup(dir_name, GPIO.OUT)
-            GPIO.setup(step_pin, GPIO.OUT)
-        except ValueError:
-            logging.warning("*** Stepper {} Pin {} initialization failure:".format(self.name, dir_name))
+        GPIO.setup(dir_name, GPIO.OUT)
+        GPIO.setup(step_pin, GPIO.OUT)
 
         # Add a key code to the key listener
         # Steppers have an nFAULT pin, so callback on falling

--- a/redeem/Stepper.py
+++ b/redeem/Stepper.py
@@ -56,13 +56,6 @@ class Stepper(object):
         ShiftRegister.make(8)
         self.shift_reg = ShiftRegister.registers[shiftreg_nr]
 
-        # Set up the GPIO pins - we just have to initialize them so the PRU can flip them
-        # terrible hack to cover a bug in Adafruit
-        dir_name = "EHRPWM2A" if dir_pin == "GPIO0_22" else dir_pin
-
-        GPIO.setup(dir_name, GPIO.OUT)
-        GPIO.setup(step_pin, GPIO.OUT)
-
         # Add a key code to the key listener
         # Steppers have an nFAULT pin, so callback on falling
         Key_pin(name, fault_key, Key_pin.FALLING, self.fault_callback)


### PR DESCRIPTION
This change undoes the GPIO initialization bits.

We don't need these if we switch to https://github.com/ThatWileyGuy/bb.org-overlays/commit/127dab50eb1127e43c03b84b35b8361018004efb for our GPIO initialization in the overlays.