### PR TITLE
Remove __release_name__

### DIFF
--- a/redeem/Redeem.py
+++ b/redeem/Redeem.py
@@ -84,9 +84,8 @@ class Redeem:
          - default is installed directory
          - allows for running in a local directory when debugging
         """
-    from __init__ import __version__, __release_name__
-    firmware_version = "{}~{}".format(__version__, __release_name__)
-    logging.info("Redeem initializing " + firmware_version)
+    from __init__ import __version__
+    logging.info("Redeem initializing {}".format(__version__))
 
     global printer
     printer = Printer()

--- a/redeem/__init__.py
+++ b/redeem/__init__.py
@@ -1,5 +1,4 @@
 # coding: utf-8
-__release_name__ = 'Red Heat'
 __url__ = "https://github.com/intelligent-agent/redeem"
 
 from ._version import get_versions


### PR DESCRIPTION
The concept of naming versions of Redeem serves no
useful purpose, creates a point of failure in
maintaining proper version recognition, and creates
non-compliant capability reports