### PR TITLE
add PathQueueIndex type to eliminate path index arithmetic bugs

### DIFF
--- a/redeem/path_planner/PathOptimizer.cpp
+++ b/redeem/path_planner/PathOptimizer.cpp
@@ -2,14 +2,14 @@
 
 #include <cmath>
 
-int64_t PathOptimizer::beforePathRemoval(std::vector<Path>& queue, size_t first, size_t last)
+int64_t PathOptimizer::beforePathRemoval(std::vector<Path>& queue, PathQueueIndex first, PathQueueIndex last)
 {
-    int64_t timeChange = -queue[first].getEstimatedTime();
+    int64_t timeChange = -queue[first.value].getEstimatedTime();
 
     if (first != last)
     {
-        Path& firstPath = queue[first];
-        Path& secondPath = queue[(first + 1) % queue.size()];
+        Path& firstPath = queue[first.value];
+        Path& secondPath = queue[(first + 1).value];
 
         // Calculate the maximum possible end speed for firstPath.
         // We're using the formula vf^2 = v0^2 + 2*a*d.
@@ -29,16 +29,16 @@ int64_t PathOptimizer::beforePathRemoval(std::vector<Path>& queue, size_t first,
     return timeChange;
 }
 
-int64_t PathOptimizer::onPathAdded(std::vector<Path>& queue, size_t first, size_t last)
+int64_t PathOptimizer::onPathAdded(std::vector<Path>& queue, PathQueueIndex first, PathQueueIndex last)
 {
-    calculateSafeSpeed(queue[last]);
+    calculateSafeSpeed(queue[last.value]);
 
-    int64_t timeChange = queue[last].getEstimatedTime();
+    int64_t timeChange = queue[last.value].getEstimatedTime();
 
     if (first != last)
     {
         // compute the junction speed for the new path
-        calculateJunctionSpeed(queue[last - 1], queue[last]);
+        calculateJunctionSpeed(queue[(last - 1).value], queue[last.value]);
     }
 
     while (first != last)
@@ -46,10 +46,10 @@ int64_t PathOptimizer::onPathAdded(std::vector<Path>& queue, size_t first, size_
         // Loop through all paths in pairs and update the junctions between them.
         // This means we'll touch everything but the end speed of the last move (which is fixed at maxSpeedJump/2)
         // and the start speed of the first move (which is fixed because the move before that is already being carried out).
-        Path& currentPath = queue[last];
+        Path& currentPath = queue[last.value];
 
-        last = (last + queue.size() - 1) % queue.size();
-        Path& previousPath = queue[last];
+        last--;
+        Path& previousPath = queue[last.value];
 
         if (currentPath.getStartSpeed() == previousPath.getMaxJunctionSpeed())
         {

--- a/redeem/path_planner/PathOptimizer.h
+++ b/redeem/path_planner/PathOptimizer.h
@@ -11,7 +11,7 @@ private:
     void calculateSafeSpeed(Path& path);
 
 public:
-    int64_t beforePathRemoval(std::vector<Path>& queue, size_t first, size_t last) override;
-    int64_t onPathAdded(std::vector<Path>& queue, size_t first, size_t last) override;
+    int64_t beforePathRemoval(std::vector<Path>& queue, PathQueueIndex first, PathQueueIndex last) override;
+    int64_t onPathAdded(std::vector<Path>& queue, PathQueueIndex first, PathQueueIndex last) override;
     void setMaxSpeedJumps(const VectorN& maxSpeedJumps);
 };

--- a/redeem/path_planner/PathOptimizerInterface.h
+++ b/redeem/path_planner/PathOptimizerInterface.h
@@ -3,10 +3,11 @@
 #include <vector>
 
 #include "Path.h"
+#include "PathQueue.h"
 
 class PathOptimizerInterface
 {
 public:
-    virtual int64_t onPathAdded(std::vector<Path>& queue, size_t first, size_t last) = 0;
-    virtual int64_t beforePathRemoval(std::vector<Path>& queue, size_t first, size_t last) = 0;
+    virtual int64_t onPathAdded(std::vector<Path>& queue, PathQueueIndex first, PathQueueIndex last) = 0;
+    virtual int64_t beforePathRemoval(std::vector<Path>& queue, PathQueueIndex first, PathQueueIndex last) = 0;
 };

--- a/redeem/path_planner/PathQueue.h
+++ b/redeem/path_planner/PathQueue.h
@@ -15,7 +15,54 @@ using namespace experimental;
 
 #include "Logger.h"
 #include "Path.h"
-#include "PathOptimizerInterface.h"
+
+struct PathQueueIndex
+{
+    size_t value;
+    size_t queueSize;
+
+    PathQueueIndex(size_t value, size_t queueSize)
+        : value(value)
+        , queueSize(queueSize)
+    {
+    }
+
+    PathQueueIndex operator+(size_t rhsRaw)
+    {
+        return PathQueueIndex((value + rhsRaw) % queueSize, queueSize);
+    }
+
+    PathQueueIndex operator-(size_t rhsRaw)
+    {
+        return PathQueueIndex((value - rhsRaw + queueSize) % queueSize, queueSize);
+    }
+
+    PathQueueIndex operator++(int)
+    {
+        PathQueueIndex temp(*this);
+        value = (value + 1) % queueSize;
+        return temp;
+    }
+
+    PathQueueIndex operator--(int)
+    {
+        PathQueueIndex temp(*this);
+        value = (value - 1 + queueSize) % queueSize;
+        return temp;
+    }
+
+    friend bool operator==(PathQueueIndex lhs, PathQueueIndex rhs)
+    {
+        return lhs.value == rhs.value && lhs.queueSize == rhs.queueSize;
+    }
+
+    friend bool operator!=(PathQueueIndex lhs, PathQueueIndex rhs)
+    {
+        return lhs.value != rhs.value || lhs.queueSize != rhs.queueSize;
+    }
+};
+
+class PathOptimizerInterface;
 
 template <typename PathOptimizerType, typename std::enable_if<std::is_base_of<PathOptimizerInterface, PathOptimizerType>::value>::type* = nullptr>
 class PathQueue
@@ -29,8 +76,8 @@ private:
     std::vector<Path> queue;
     uint64_t maxTime;
     uint64_t curTime;
-    size_t writeIndex;
-    size_t readIndex;
+    PathQueueIndex writeIndex;
+    PathQueueIndex readIndex;
     size_t availableSlots;
     bool running;
 
@@ -62,11 +109,11 @@ private:
             return false;
         }
 
-        queue[writeIndex] = std::move(path);
+        queue[writeIndex.value] = std::move(path);
 
         curTime += optimizer.onPathAdded(queue, readIndex, writeIndex);
 
-        writeIndex = (writeIndex + 1) % queue.size();
+        writeIndex++;
         availableSlots--;
 
         if (availableSlots == queue.size() - 1)
@@ -83,8 +130,8 @@ public:
         , queue(size)
         , maxTime(maxTime)
         , curTime(0)
-        , writeIndex(0)
-        , readIndex(0)
+        , writeIndex(0, size)
+        , readIndex(0, size)
         , availableSlots(size)
         , running(true)
     {
@@ -127,13 +174,13 @@ public:
             return std::optional<Path>();
         }
 
-        const size_t currentReadIndex = readIndex;
+        const PathQueueIndex currentReadIndex = readIndex;
         const bool addPathMightBeBlocking = !doesQueueHaveSpace();
 
         // subtract one because the optimizer does touch the last index
-        curTime += optimizer.beforePathRemoval(queue, readIndex, (writeIndex + queue.size() - 1) % queue.size());
+        curTime += optimizer.beforePathRemoval(queue, readIndex, writeIndex - 1);
 
-        readIndex = (readIndex + 1) % queue.size();
+        readIndex++;
         availableSlots++;
 
         if (addPathMightBeBlocking && doesQueueHaveSpace())
@@ -146,7 +193,7 @@ public:
             queueIsEmpty.notify_all();
         }
 
-        return std::move(queue[currentReadIndex]);
+        return std::move(queue[currentReadIndex.value]);
     }
 
     bool queueSyncEvent(SyncCallback& callback, bool blocking)
@@ -158,13 +205,13 @@ public:
             return false;
         }
 
-        const size_t lastPathIndex = (writeIndex + queue.size() - 1) % queue.size();
+        const PathQueueIndex lastPathIndex = writeIndex - 1;
 
         if (queue.size() - availableSlots > 0
-            && !queue[lastPathIndex].isSyncEvent()
-            && !queue[lastPathIndex].isSyncWaitEvent())
+            && !queue[lastPathIndex.value].isSyncEvent()
+            && !queue[lastPathIndex.value].isSyncWaitEvent())
         {
-            Path& lastPath = queue[(writeIndex + queue.size() - 1) % queue.size()];
+            Path& lastPath = queue[lastPathIndex.value];
             lastPath.setSyncEvent(callback, blocking);
             return true;
         }


### PR DESCRIPTION
The alternative to something like this is to keep using size_t as the index type but build a circular_queue abstraction that sits on top of the std::vector.