### PR TITLE
Comment path planner assert until it's fixed

### DIFF
--- a/redeem/path_planner/Path.cpp
+++ b/redeem/path_planner/Path.cpp
@@ -367,7 +367,7 @@ void Path::updateStepperPathParameters()
             // doesn't check that the end speed of a move is reachable from the start speed within
             // limits. This hasn't been a problem because it only affects moves that are only a few
             // steps in the first place. However, when it occurs, this assert will fire.
-            assert(std::abs(cruiseDistance) < NEGLIGIBLE_ERROR);
+            //assert(std::abs(cruiseDistance) < NEGLIGIBLE_ERROR);
 
             if (accelDistance == 0)
             {


### PR DESCRIPTION
This has been breaking people's prints. It was commented out under the old path planner - I uncommented it during the rewrite because I hope to address it. At this point I understand the underlying issue, but it's a challenge to fix because it's due to conflicting assumptions in how the optimizer is implemented.