### PR TITLE
Fix enabling stepper current for a4a boards

### DIFF
--- a/redeem/Printer.py
+++ b/redeem/Printer.py
@@ -125,9 +125,15 @@ class Printer:
         if not stepper.enabled:
           # Stepper should be enabled, but is not.
           stepper.set_enabled(True)    # Force update
-        if not stepper.current_enabled:
-          # Stepper does not have current enabled.
-          stepper.set_current_enabled()    # Force update
+        try:
+          if not stepper.current_enabled:
+            # Stepper does not have current enabled.
+            stepper.set_current_enabled()    # Force update
+        except:
+          # Logic needed for replicate a4a
+          if hasattr( stepper, "current_enabled" ):
+            # Stepper does not have current enabled.
+            stepper.set_current_enabled()    # Force update
 
   def reply(self, gcode):
     """ Send a reply through the proper channel """


### PR DESCRIPTION
Newer board versions have been updated with a new API, but the
a4a has not been updated.

More information on the issue:
https://bitbucket.org/intelligentagent/redeem/issues/173/error-while-executing-g1-stepper_00a4