### PR TITLE
Apply Probe Z offset to G30

### DIFF
--- a/redeem/gcodes/G30.py
+++ b/redeem/gcodes/G30.py
@@ -64,6 +64,7 @@ class G30(GCodeCommand):
     # values in config file are in metres, need to convert to millimetres
     offset_x = self.printer.config.getfloat('Probe', 'offset_x') * 1000
     offset_y = self.printer.config.getfloat('Probe', 'offset_y') * 1000
+    offset_z = self.printer.config.getfloat('Probe', 'offset_z') * 1000
 
     logging.debug("G30: probing from point (mm) : X{} Y{} Z{}".format(
         point["X"] + offset_x, point["Y"] + offset_y, point["Z"]))
@@ -78,9 +79,13 @@ class G30(GCodeCommand):
     self.printer.processor.resolve(G0)
     self.printer.processor.execute(G0)
     self.printer.path_planner.wait_until_done()
-    bed_dist = round(
-        self.printer.path_planner.probe(probe_length, probe_speed, probe_accel) * 1000.0,
-        3)    # convert to mm
+
+    bed_dist = self.printer.path_planner.probe(probe_length, probe_speed,
+                                               probe_accel) * 1000.0    # convert to mm
+    logging.info("G30: adjusting offset using Z-probe offset by " + str(offset_z))
+    bed_dist = bed_dist - offset_z # apply z offset
+    bed_dist = round( bed_dist, 3)
+
     logging.debug("Bed dist: " + str(bed_dist) + " mm")
 
     self.printer.send_message(
@@ -167,6 +172,7 @@ class G30_1(GCodeCommand):
     # values in config file are in metres, need to convert to millimetres
     offset_x = self.printer.config.getfloat('Probe', 'offset_x') * 1000
     offset_y = self.printer.config.getfloat('Probe', 'offset_y') * 1000
+    offset_z = self.printer.config.getfloat('Probe', 'offset_z') * 1000
 
     logging.debug("G30.1: probing from point (mm) : X{} Y{} Z{}".format(
         point["X"] + offset_x, point["Y"] + offset_y, point["Z"]))
@@ -183,6 +189,8 @@ class G30_1(GCodeCommand):
     self.printer.path_planner.wait_until_done()
     bed_dist = self.printer.path_planner.probe(probe_length, probe_speed,
                                                probe_accel) * 1000.0    # convert to mm
+    logging.info("G30: adjusting offset using Z-probe offset by " + str(offset_z))
+    bed_dist = bed_dist - offset_z # apply z offset
 
     # calculated required offset to make bed equal to Z0 or user's specified Z.
     # should be correct, assuming probe starts at Z(5), requested Z(0)  probe Z(-0.3), adjusted global Z should be 5.3

--- a/redeem/gcodes/G30.py
+++ b/redeem/gcodes/G30.py
@@ -83,8 +83,8 @@ class G30(GCodeCommand):
     bed_dist = self.printer.path_planner.probe(probe_length, probe_speed,
                                                probe_accel) * 1000.0    # convert to mm
     logging.info("G30: adjusting offset using Z-probe offset by " + str(offset_z))
-    bed_dist = bed_dist - offset_z # apply z offset
-    bed_dist = round( bed_dist, 3)
+    bed_dist = bed_dist - offset_z    # apply z offset
+    bed_dist = round(bed_dist, 3)
 
     logging.debug("Bed dist: " + str(bed_dist) + " mm")
 
@@ -190,7 +190,7 @@ class G30_1(GCodeCommand):
     bed_dist = self.printer.path_planner.probe(probe_length, probe_speed,
                                                probe_accel) * 1000.0    # convert to mm
     logging.info("G30: adjusting offset using Z-probe offset by " + str(offset_z))
-    bed_dist = bed_dist - offset_z # apply z offset
+    bed_dist = bed_dist - offset_z    # apply z offset
 
     # calculated required offset to make bed equal to Z0 or user's specified Z.
     # should be correct, assuming probe starts at Z(5), requested Z(0)  probe Z(-0.3), adjusted global Z should be 5.3

--- a/redeem/gcodes/G33.py
+++ b/redeem/gcodes/G33.py
@@ -44,11 +44,7 @@ class G33(GCodeCommand):
       self.printer.path_planner.wait_until_done()
 
     # adjust probe heights
-    probe_z_coords = np.array(self.printer.probe_heights[:len(self.printer.probe_points)])
-    offset_z = self.printer.config.getfloat('Probe', 'offset_z') * 1000.
-    logging.info("G33: adjusting offset using Z-probe offset by " + str(offset_z))
-    # this is where the print head was when the probe was triggered
-    print_head_zs = probe_z_coords - offset_z
+    print_head_zs = np.array(self.printer.probe_heights[:len(self.printer.probe_points)])
 
     # Log the found heights
     logging.info("G33: Found heights: " + str(np.round(print_head_zs, 2)))

--- a/tests/gcode/test_G33.py
+++ b/tests/gcode/test_G33.py
@@ -33,8 +33,8 @@ class G33_Tests(MockPrinter):
       self.assertEqual(v, mock_Gcode.call_args_list[i][0][0]["message"])
 
   def test_gcodes_G33_correct_args_to_autocalibrate_delta_printer(self):
-    offset_z = self.printer.config.set('Probe', 'offset_z',
-                                       str(-0.0012))    # arbitrary probe offset, -1.2mm
+    """ Set probe offset to 0. Since processor.execute has been mocked the G33 code will not actually execute G30 commands """
+    offset_z = self.printer.config.set('Probe', 'offset_z', str(0.000))
     self.printer.probe_points = [    # roughly 120 degree equalateral triangle, 30mm off the deck
         {0.080, 0.0, 0.030}, {-0.040, 0.070, 0.030}, {-0.040, -0.070, 0.030}
     ]
@@ -54,4 +54,4 @@ class G33_Tests(MockPrinter):
                   set([-0.04, 0.070, 0.03]),
                   set([-0.04, -0.070, 0.03])]))
     np.testing.assert_array_equal(
-        np.round(autocal_call_args[3], 3), np.array([1.231, 1.232, 1.233]))
+        np.round(autocal_call_args[3], 3), np.array([0.031, 0.032, 0.033]))


### PR DESCRIPTION
G30 previously took the X and Y probe offsets into account when
probing a given position. This allow getting bed information for
where the hotend should be instead of measuring at an offset
position.

This takes the Z offset into account when returning the probe
information. This also removes the offset from being indirectly
applied with the G33 commands.