### PR TITLE
speed up shutdowns

### DIFF
--- a/redeem/Alarm.py
+++ b/redeem/Alarm.py
@@ -185,7 +185,7 @@ class AlarmExecutor:
 
   def stop(self):
     if self.running:
-      logging.debug("Stoppping alarm executor")
+      logging.debug("Stopping alarm executor")
       self.running = False
       self.t.join()
     else:

--- a/redeem/EndStop.py
+++ b/redeem/EndStop.py
@@ -26,8 +26,7 @@ import logging
 import re
 from evdev import InputDevice, ecodes
 from PruInterface import *
-from select import select
-from threading import Thread
+from Key_pin import Key_pin
 
 
 class EndStop:
@@ -57,11 +56,10 @@ class EndStop:
     # Update "hit" state
     self.read_value()
 
-    self.running = True
-    self.t = Thread(target=self._wait_for_event, name=self.name)
-    self.t.daemon = True
+    logging.debug("starting endstop %s", self.name)
+
+    self.key_pin = Key_pin(self.name + "_pin", self.key_code, 0xff, self._handle_event)
     self.active = True
-    self.t.start()
 
   def get_gpio_bank_and_pin(self):
     matches = re.compile(r'GPIO([0-9])_([0-9]+)').search(self.pin)
@@ -70,36 +68,23 @@ class EndStop:
     return tup
 
   def stop(self):
-    self.running = False
     logging.debug("End stop {} stopping".format(self.name))
-    self.t.join()
 
   def get_pin(self):
     return self.pin
 
-  def _wait_for_event(self):
-    while self.running:
-      #logging.debug("End stop {} waiting".format(self.name))
-      r, w, x = select([self.dev], [], [], 3)
-      if r:
-        #logging.debug("End stop {} event".format(self.name))
-        for event in self.dev.read():
-          if event.type == ecodes.EV_KEY:
-            if event.code == self.key_code:
-              if self.invert:
-                if int(event.value):
-                  self.hit = True
-                  self.callback()
-                else:
-                  self.hit = False
-              elif not self.invert:
-                if not int(event.value):
-                  self.hit = True
-                  self.callback()
-                else:
-                  self.hit = False
-      #else:
-      #    logging.debug("End stop {} timeout".format(self.name))
+  def _handle_event(self, key, event):
+    if self.invert:
+      if int(event.value):
+        self.hit = True
+      else:
+        self.hit = False
+    elif not self.invert:
+      if not int(event.value):
+        self.hit = True
+      else:
+        self.hit = False
+    self.callback()
 
   def read_value(self):
     """ Read the current endstop value from GPIO using PRU1 """
@@ -108,11 +93,12 @@ class EndStop:
 
   def callback(self):
     """ An endStop has been hit """
-    logging.info("End Stop " + self.name + " hit!")
-    if "toggle" in self.printer.comms:
-      self.printer.comms["toggle"].send_message("End stop {} hit!".format(self.name))
-    if "octoprint" in self.printer.comms:
-      self.printer.comms["octoprint"].send_message("End stop {} hit!".format(self.name))
+    type_string = "hit" if self.hit else "released"
+    event_string = "End Stop {} {}!".format(self.name, type_string)
+    logging.info(event_string)
+    for channel in ["octoprint", "toggle"]:
+      if channel in self.printer.comms:
+        self.printer.comms[channel].send_message(event_string)
 
 
 if __name__ == "__main__":

--- a/redeem/IOManager.py
+++ b/redeem/IOManager.py
@@ -1,0 +1,100 @@
+import threading
+import os
+import select
+import sys
+import Queue
+import logging
+
+
+class IOManager:
+  thread = None
+  control_pipe = None
+  control_queue = None
+
+  def __init__(self):
+    self.control_queue = Queue.Queue()
+    read_fd, write_fd = os.pipe()
+    self.control_pipe = os.fdopen(write_fd, 'w')
+    thread_pipe = os.fdopen(read_fd, 'r')
+    logging.debug("IOManager starting up")
+    self.thread = threading.Thread(target=self._thread_loop, name="IOManager", args=[thread_pipe])
+    self.thread.start()
+
+  def stop(self):
+    logging.debug("IOManager shutting down")
+
+    def stop_handler(poller, callbacks):
+      return False
+
+    self.control_queue.put(stop_handler)
+    self._wake_io_thread()
+    self.control_queue.join()
+    self.thread.join()
+    logging.debug("IOManager done shutting down")
+
+  def is_running(self):
+    return self.thread is not None and self.thread.is_alive()
+
+  def add_file(self, file, callback):
+    logging.debug("IOManager adding file: %s", str(file))
+
+    def add_handler(poller, callbacks):
+      poller.register(
+          file, select.POLLIN | select.POLLPRI | select.POLLERR | select.POLLHUP | select.POLLNVAL)
+      callbacks[file.fileno()] = callback
+      logging.debug("IOManager thread added file successfully")
+      return True
+
+    self.control_queue.put(add_handler)
+    self._wake_io_thread()
+    self.control_queue.join()
+
+  def remove_file(self, file):
+    logging.debug("IOManager removing file: %s", str(file))
+
+    def remove_handler(poller, callbacks):
+      poller.unregister(file)
+      del callbacks[file.fileno()]
+      logging.debug("IOManager thread removed file successfully")
+      return True
+
+    self.control_queue.put(remove_handler)
+    self._wake_io_thread()
+    self.control_queue.join()
+
+  def _wake_io_thread(self):
+    self.control_pipe.write(" ")
+    self.control_pipe.flush()
+
+  def _thread_loop(self, control_pipe):
+    try:
+      keep_running = True
+      callbacks = {}
+      poller = select.poll()
+      poller.register(control_pipe)
+      while keep_running:
+        active_fds = poller.poll()
+        for fd, flag in active_fds:
+          if fd == control_pipe.fileno():
+            logging.debug("IOManagerThread processing control events")
+            keep_running = self._handle_events(control_pipe, poller, callbacks)
+            logging.debug("IOManagerThread finished processing control events")
+          else:
+            try:
+              logging.debug("IOManagerThread calling callback %s with flags %s", str(fd), str(flag))
+              callbacks[fd](flag)
+            except:
+              logging.warn("IOManager caught exception from a callback: %s", str(sys.exc_info()))
+    except:
+      logging.error("IOManager terminating due to %s", str(sys.exc_info()))
+    logging.debug("IOManager terminating")
+
+  def _handle_events(self, control_pipe, poller, callbacks):
+    control_pipe.read(1)
+    keep_running = True
+    while not self.control_queue.empty():
+      control_item = self.control_queue.get_nowait()
+      keep_running = keep_running and control_item(poller, callbacks)
+      self.control_queue.task_done()
+      logging.debug("IOManager finished control item")
+    return keep_running

--- a/tests/core/test_IOManager.py
+++ b/tests/core/test_IOManager.py
@@ -1,0 +1,105 @@
+from __future__ import print_function
+import mock
+import unittest
+import os
+import threading
+import select
+
+#Make test version- agnostic:
+from sys import version_info
+if version_info.major == 2:
+  import __builtin__ as builtins    # pylint:disable=import-error
+else:
+  import builtins    # pylint:disable=import-error
+
+from IOManager import IOManager
+
+
+class PipeWrapper:
+  def __init__(self):
+    read_fd, write_fd = os.pipe()
+    print("pipe read_fd: " + str(read_fd))
+    self.writer = os.fdopen(write_fd, 'w')
+    self.reader = os.fdopen(read_fd, 'r')
+
+  def send(self, msg):
+    self.writer.write(msg)
+    self.writer.flush()
+
+
+class TestIOManager(unittest.TestCase):
+  def setUp(self):
+    self.manager = IOManager()
+
+  def tearDown(self):
+    if self.manager.is_running():
+      self.manager.stop()
+
+  def test_starts_and_stops(self):
+    pass
+
+  def test_is_running(self):
+    self.assertTrue(self.manager.is_running())
+    self.manager.stop()
+    self.assertFalse(self.manager.is_running())
+
+  def test_calls_callbacks(self):
+    pipe = PipeWrapper()
+    event = threading.Event()
+
+    def callback(flag):
+      if flag == select.POLLIN:
+        text = pipe.reader.readline()
+        if text == "super beans\n":
+          event.set()
+      else:
+        self.assertEqual(flag, select.POLLHUP)
+
+    self.manager.add_file(pipe.reader, lambda flag: callback(flag))
+
+    self.assertFalse(event.is_set())
+    pipe.send("super beans\n")
+    event.wait(1)
+    self.assertTrue(event.is_set())
+
+  def test_removes_callbacks(self):
+    pipe = PipeWrapper()
+    event = threading.Event()
+
+    def callback(flag):
+      if flag == select.POLLIN:
+        text = pipe.reader.readline()
+        if text == "super beans\n":
+          event.set()
+      else:
+        self.assertEqual(flag, select.POLLHUP)
+
+    self.manager.add_file(pipe.reader, lambda flag: callback(flag))
+
+    self.assertFalse(event.is_set())
+    pipe.send("super beans\n")
+    event.wait(1)
+    self.assertTrue(event.is_set())
+
+    event.clear()
+
+    self.manager.remove_file(pipe.reader)
+
+    self.assertFalse(event.is_set())
+    pipe.send("super beans\n")
+    event.wait(0.05)    # note that this will always be taken - the callback shouldn't fire
+    self.assertFalse(event.is_set())
+
+  def test_sends_hangups(self):
+    pipe = PipeWrapper()
+    event = threading.Event()
+
+    def callback(flag):
+      if flag != select.POLLHUP and flag != select.POLLNVAL:
+        self.assertEqual(flag, select.POLLHUP | select.POLLNVAL)
+      event.set()
+
+    self.manager.add_file(pipe.reader, callback)
+    pipe.writer.close()
+    event.wait(1)
+    self.assertTrue(event.is_set())

--- a/tests/gcode/MockPrinter.py
+++ b/tests/gcode/MockPrinter.py
@@ -33,6 +33,8 @@ sys.modules['redeem.Pipe'] = mock.Mock()
 sys.modules['redeem.Fan'] = mock.Mock()
 sys.modules['redeem.Mosfet'] = mock.Mock()
 sys.modules['redeem.PWM'] = mock.Mock()
+sys.modules['redeem.IOManager'] = mock.Mock()
+sys.modules['redeem.IOManager'].IOManager = mock.MagicMock()
 
 from redeem.CascadingConfigParser import CascadingConfigParser
 from redeem.Redeem import *
@@ -97,7 +99,6 @@ version = 1
   # instantiated, still need to mock the initialization of the native planner (`_init_path_planner`).
 
   @classmethod
-  @mock.patch.object(EndStop, "_wait_for_event", new=None)
   @mock.patch.object(PathPlanner, "_init_path_planner")
   @mock.patch("redeem.Redeem.CascadingConfigParser", new=CascadingConfigParserWedge)
   def setUpClass(cls, mock_init_path_planner):


### PR DESCRIPTION
This PR combines most of Redeem's threads sitting in select-loops into an IOManager class. This reduces the number of OS threads we need overall and makes shutdown nearly instantaneous. Additionally, the Heaters (which do still need threads) are waiting on Events now, which let them stop quickly as well.