### PR TITLE
Address #181 : Fail to set A4A motor current on 2.2.1-RC2

### DIFF
--- a/redeem/DAC.py
+++ b/redeem/DAC.py
@@ -58,10 +58,7 @@ class DAC():
     self.offset = 0.0
     if 'SPI' in globals():
       # init the SPI for the DAC
-      try:
-        self.spi2_0 = SPI(0, 0)
-      except IOError:
-        self.spi2_0 = SPI(1, 0)
+      self.spi2_0 = SPI(2, 0)
       self.spi2_0.bpw = 8
       self.spi2_0.mode = 1
     else:


### PR DESCRIPTION
Umikaze 2.2.1-RC2 includes updated versions of Adafruit-BBIO
This new library changes how the SPI module works.

This changes the DAC class to match the updated SPI module
to use /dev/spidev2_0