### PR TITLE
G28 - Don’t send second “ok”

### DIFF
--- a/redeem/gcodes/G28.py
+++ b/redeem/gcodes/G28.py
@@ -42,7 +42,7 @@ class G28(GCodeCommand):
 
     logging.info("Homing done.")
     self.printer.send_message(g.prot, "Homing done.")
-    self.printer.send_message(g.prot, "ok")
+    # self.printer.send_message(g.prot, "ok")
 
   def get_description(self):
     return "Move the steppers to their homing position" \


### PR DESCRIPTION
When homing, the `G28` command issues two "OK" messages for the one command issued.

This can cause the UI host to think that an additional command has been accepted.
