### PR TITLE
M115

### DIFF
--- a/redeem/DAC.py
+++ b/redeem/DAC.py
@@ -23,6 +23,7 @@ License: GNU GPL v3: http://www.gnu.org/copyleft/gpl.html
  along with Redeem.  If not, see <http://www.gnu.org/licenses/>.
 """
 from __future__ import absolute_import
+
 import time
 import logging
 from .PWM import PWM

--- a/redeem/Redeem.py
+++ b/redeem/Redeem.py
@@ -33,8 +33,10 @@ from threading import Thread
 from threading import enumerate as enumerate_threads
 if PY2:
   import Queue as queue
+  from Queue import Empty as EmptyQueueException
 else:
   import queue
+  from queue import Empty as EmptyQueueException
 
 from .Alarm import Alarm, AlarmExecutor
 from .CascadingConfigParser import CascadingConfigParser
@@ -587,7 +589,7 @@ class Redeem:
       while RedeemIsRunning:
         try:
           gcode = the_queue.get(block=True, timeout=1)
-        except queue.Empty:
+        except EmptyQueueException:
           continue
         logging.debug("Executing " + gcode.code() + " from " + name + " " + gcode.message)
         self._execute(gcode)

--- a/redeem/Stepper.py
+++ b/redeem/Stepper.py
@@ -130,6 +130,8 @@ D7 = CFG1-Z  = 0 (microstepping)
 
 
 class Stepper_00B1(Stepper):
+  revision = "B1"
+
   def __init__(self, stepPin, dirPin, faultPin, dac_channel, shiftreg_nr, name):
     Stepper.__init__(self, stepPin, dirPin, faultPin, dac_channel, shiftreg_nr, name)
     self.dac = PWM_DAC(dac_channel)
@@ -242,6 +244,8 @@ class Stepper_00B1(Stepper):
 
 
 class Stepper_00B2(Stepper_00B1):
+  revision = "B2"
+
   def __init__(self, stepPin, dirPin, faultPin, dac_channel, shiftreg_nr, name):
     Stepper_00B1.__init__(self, stepPin, dirPin, faultPin, dac_channel, shiftreg_nr, name)
     self.dac = PWM_DAC(dac_channel)
@@ -279,6 +283,8 @@ class Stepper_00B2(Stepper_00B1):
 
 
 class Stepper_00B3(Stepper_00B2):
+  revision = "B3"
+
   @classmethod
   def set_stepper_power_down(self, pd):
     ''' Enables stepper low current mode on all steppers '''

--- a/redeem/gcodes/M115.py
+++ b/redeem/gcodes/M115.py
@@ -31,6 +31,7 @@ class M115(GCodeCommand):
     f.close()
     distro_name = l[0]
     distro_version = l[1]
+    python_version = os.sys.version.split(' ')[0]
     g.set_answer(
         "ok " \
         "PROTOCOL_VERSION:{} "\
@@ -42,6 +43,7 @@ class M115(GCodeCommand):
         "KERNEL:{} "\
         "DISTRIBUTION_NAME:{} "\
         "DISTRIBUTION_VERSION:{} "\
+        "PYTHON_VERSION:{} "\
         "EXTRUDER_COUNT:{}"\
         .format(
             protocol_version,
@@ -53,6 +55,7 @@ class M115(GCodeCommand):
             kernel,
             distro_name,
             distro_version,
+            python_version,
             extruder_count
         )
     )

--- a/redeem/gcodes/M280.py
+++ b/redeem/gcodes/M280.py
@@ -29,13 +29,13 @@ class M280(GCodeCommand):
       speed = 100
     # If "R" is present, be synchronous
     if g.has_letter("R"):
-      async = False
+      asynchronous = False
     else:
-      async = True
+      asynchronous = True
     # Index of servo
     if index < len(self.printer.servos):
       servo = self.printer.servos[index]
-      servo.set_angle(angle, speed, async)
+      servo.set_angle(angle, speed, asynchronous)
     else:
       logging.warning("M280: Servo index out of range " + str(index))
 

--- a/tests/gcode/MockPrinter.py
+++ b/tests/gcode/MockPrinter.py
@@ -51,7 +51,7 @@ Override CascadingConfigParser methods to set self. variables
 
 class CascadingConfigParserWedge(CascadingConfigParser):
   def parse_capes(self):
-    self.replicape_revision = "0A4A"    # Fake. No hardware involved in these tests (Redundant?)
+    self.replicape_revision = "0B3A"    # Fake. No hardware involved in these tests (Redundant?)
     self.reach_revision = "00A0"    # Fake. No hardware involved in these tests (Redundant?)
 
 
@@ -63,10 +63,11 @@ class MockPrinter(unittest.TestCase):
   """
   """
   handy conversion from microstep config to microstep multiplier
-  this is inherently tied to the stepper class the MockPrinter is using - right now it's 00A4
+  this is inherently tied to the stepper class the MockPrinter is using - right now it's 0B3A
+  for the A series, this is [1, 2, 4, 8, 16, 32]
   for the B series that use TMC2100s, this is [1, 2, 2, 4, 16, 4, 16, 4, 16]
   """
-  microstep_config_to_multiplier = [1, 2, 4, 8, 16, 32]
+  microstep_config_to_multiplier = {'A': [1, 2, 4, 8, 16, 32], 'B': [1, 2, 2, 4, 16, 4, 16, 4, 16]}
 
   @classmethod
   def setUpPatch(cls):

--- a/tests/gcode/test_M19.py
+++ b/tests/gcode/test_M19.py
@@ -3,11 +3,11 @@ from __future__ import absolute_import
 from .MockPrinter import MockPrinter
 import mock
 from six import iteritems
-from redeem.Stepper import Stepper_00A4
+from redeem.Stepper import Stepper_00B3
 
 
 class M19_Tests(MockPrinter):
-  @mock.patch.object(Stepper_00A4, "reset")
+  @mock.patch.object(Stepper_00B3, "reset")
   def test_gcodes_M19(self, m):
     self.execute_gcode("M19")
     self.printer.path_planner.wait_until_done.assert_called()

--- a/tests/gcode/test_M909.py
+++ b/tests/gcode/test_M909.py
@@ -1,19 +1,21 @@
 from __future__ import absolute_import
 
-from .MockPrinter import MockPrinter
-from numpy.testing import assert_array_equal
-import numpy
 import mock
+import numpy
+from numpy.testing import assert_array_equal
+from .MockPrinter import MockPrinter
 
 
 class M909_Tests(MockPrinter):
   def setUp(self):
     self.steps_pr_mm = {}
     self.microstep_configs = {}
+    self.stepper_type = {}
 
     for axis, stepper in self.printer.steppers.items():
       self.steps_pr_mm[axis] = stepper.steps_pr_mm
       self.microstep_configs[axis] = stepper.microstepping
+      self.stepper_type[axis] = stepper.revision[0]
 
     self.printer.path_planner.update_steps_pr_meter = mock.Mock()
 
@@ -34,8 +36,8 @@ class M909_Tests(MockPrinter):
 
     for axis_num in range(self.printer.num_axes):
       axis = self.printer.index_to_axis(axis_num)
-      expected_microsteps.append(self.steps_pr_mm[axis] *
-                                 self.microstep_config_to_multiplier[self.microstep_configs[axis]])
+      expected_microsteps.append(self.steps_pr_mm[axis] * self.microstep_config_to_multiplier[
+          self.stepper_type[axis]][self.microstep_configs[axis]])
 
     assert_array_equal(expected_microsteps, printer_microsteps)
 


### PR DESCRIPTION
Since we are working on migrating Redeem to Python3, it becomes useful to be able to display the version of Python being used by the particular instance of the daemon.

Since M115 outputs a line of descriptors, I have added a "PYTHON_VERSION" to that output.
